### PR TITLE
Implement observables API and autocorrelation time computation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1178,6 +1178,7 @@ dependencies = [
  "atomic_float",
  "criterion",
  "hdf5-metno",
+ "lqft-derive",
  "ndarray",
  "nohash-hasher",
  "num-traits",
@@ -1189,6 +1190,7 @@ dependencies = [
  "rayon",
  "realfft",
  "rustfft",
+ "static_assertions",
  "sysinfo",
  "tokio",
  "tracing",
@@ -1199,6 +1201,11 @@ dependencies = [
 [[package]]
 name = "lqft-derive"
 version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "matrixmultiply"
@@ -2100,6 +2107,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strength_reduce"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2107,9 +2120,9 @@ checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "syn"
-version = "2.0.116"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df424c70518695237746f84cede799c9c58fcb37450d7b23716568cc8bc69cb"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,19 +239,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
-name = "console"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "unicode-width",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,12 +442,6 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -1047,19 +1028,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indicatif"
-version = "0.18.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
-dependencies = [
- "console",
- "portable-atomic",
- "unicode-width",
- "unit-prefix",
- "web-time",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,18 +1178,17 @@ dependencies = [
  "atomic_float",
  "criterion",
  "hdf5-metno",
- "indicatif",
  "ndarray",
  "nohash-hasher",
  "num-traits",
- "phf",
  "plotters",
  "prometheus 0.14.0",
  "prometheus_exporter",
  "rand",
  "rand_xoshiro",
  "rayon",
- "serde",
+ "realfft",
+ "rustfft",
  "sysinfo",
  "tokio",
  "tracing",
@@ -1499,25 +1466,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "phf"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
-dependencies = [
- "phf_shared",
- "serde",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1626,6 +1574,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "primal-check"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
+dependencies = [
+ "num-integer",
 ]
 
 [[package]]
@@ -1829,6 +1786,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "realfft"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f821338fddb99d089116342c46e9f1fbf3828dba077674613e734e01d6ea8677"
+dependencies = [
+ "rustfft",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1920,6 +1886,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustfft"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21db5f9893e91f41798c88680037dba611ca6674703c1a18601b01a72c8adb89"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
 ]
 
 [[package]]
@@ -2086,12 +2066,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
-name = "siphasher"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
-
-[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2124,6 +2098,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "syn"
@@ -2475,6 +2455,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2493,22 +2483,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unit-prefix"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "url"
@@ -2681,16 +2659,6 @@ name = "web-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ overflow-checks = false
 #lto = "fat"
 incremental = false
 codegen-units = 16
+panic = "abort"

--- a/lqft-derive/Cargo.toml
+++ b/lqft-derive/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2024"
 proc-macro = true
 
 [dependencies]
+proc-macro2 = "1.0.106"
+quote = "1.0.44"
+syn = "2.0.117"

--- a/lqft-derive/src/lib.rs
+++ b/lqft-derive/src/lib.rs
@@ -1,0 +1,23 @@
+use proc_macro::{TokenStream};
+use proc_macro2::Span;
+use syn::Ident;
+
+#[proc_macro_derive(Observable)]
+pub fn derive_observable(stream: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(stream as syn::DeriveInput);
+
+    let vis = input.vis;
+    let name = input.ident;
+    let name_str = name.to_string();
+    let state_name = Ident::new(&format!("__{name}ObservableState"), Span::call_site());
+
+    let expanded = quote::quote! {
+        impl crate::setup::Observable2 for #name {
+            const NAME: &'static str = #name_str;
+
+            
+        }
+    };
+
+    TokenStream::from(expanded)
+}

--- a/lqft/Cargo.toml
+++ b/lqft/Cargo.toml
@@ -24,5 +24,8 @@ tracing = "0.1.44"
 tracing-loki = "0.2.6"
 tracing-subscriber = "0.3.22"
 
+lqft-derive = { path = "../lqft-derive" }
+static_assertions = "1.1.0"
+
 [dev-dependencies]
 criterion = "0.8.2"

--- a/lqft/Cargo.toml
+++ b/lqft/Cargo.toml
@@ -7,18 +7,17 @@ edition = "2024"
 anyhow = "1.0.101"
 atomic_float = "1.1.0"
 hdf5-metno = { version = "0.12.3", features = ["static", "zlib"] }
-indicatif = "0.18.4"
 ndarray = "0.17.2"
 nohash-hasher = "0.2.0"
 num-traits = "0.2.19"
-phf = "0.13.1"
 plotters = "0.3.7"
 prometheus = "0.14.0"
 prometheus_exporter = { git = 'https://github.com/AlexanderThaller/prometheus_exporter.git', rev = 'c49efe614486f998b20eb410ae0caf3e904cf540' }
 rand = "0.10.0"
 rand_xoshiro = "0.8.0"
 rayon = "1.11.0"
-serde = { version = "1.0.228", features = ["derive"] }
+realfft = "3.5.0"
+rustfft = "6.4.1"
 sysinfo = "0.38.2"
 tokio = { version = "1.49.0", features = ["rt", "rt-multi-thread", "macros"] }
 tracing = "0.1.44"

--- a/lqft/src/lattice.rs
+++ b/lqft/src/lattice.rs
@@ -1,18 +1,12 @@
-use crate::setup::{InitialState, LatticeCreateDesc, LatticeDesc, LatticeIterMethod, LatticeLoadDesc, SnapshotLocation};
+use crate::setup::{InitialState, LatticeCreateDesc, LatticeIterMethod, LatticeLoadDesc, SnapshotLocation};
 use anyhow::Context;
 use hdf5_metno as hdf5;
-use ndarray::{Array4, Array5, ArrayView4, ArrayView5};
-use num_traits::Pow;
-use rand::{Rng, RngExt};
-use std::cell::UnsafeCell;
-use std::ops::{Deref, Index};
+use ndarray::{Array5, ArrayView4};
+use rand::{RngExt};
 use std::ops::Range;
 use std::str::FromStr;
 
 use rayon::prelude::*;
-
-/// 2 adjacent indices in each dimension.
-type AdjacentIndices = [usize; 8];
 
 #[derive(Clone)]
 pub struct Lattice {
@@ -118,12 +112,14 @@ impl Lattice {
         self.iter_method
     }
 
-    pub fn from_view(view: ArrayView4<f64>, spacing: f64, iter_method: LatticeIterMethod) -> Self {
-        let dimensions: (usize, usize, usize, usize) = view.dim();
+    pub fn from_view(_view: ArrayView4<f64>, _spacing: f64, _iter_method: LatticeIterMethod) -> Self {
+        todo!();
 
-        let count = view.len().div_ceil(2);
-        let mut red_sites = vec![0.0; count];
-        let mut black_sites = vec![0.0; count];
+        // let dimensions: (usize, usize, usize, usize) = view.dim();
+
+        // let count = view.len().div_ceil(2);
+        // let mut red_sites = vec![0.0; count];
+        // let mut black_sites = vec![0.0; count];
 
         // for t in 0..dimensions.0 {
         //     for x in 0..dimensions.1 {
@@ -139,7 +135,6 @@ impl Lattice {
         //         }
         //     }
         // }
-        todo!();
 
         // let mut lattice = Lattice {
         //     iter_method,
@@ -187,30 +182,6 @@ impl Lattice {
         tracing::debug!("Checkerboard generated!");
 
         (red, black)
-    }
-
-    /// Generates an adjacency table for the specified lattice.
-    fn generate_adjacency(&mut self) -> Vec<AdjacentIndices> {
-        let total_indices = self.sweep_size();
-        let mut table = Vec::with_capacity(total_indices);
-
-        for i in 0..total_indices {
-            let mut neighbors = [0; 8];
-
-            for j in 0..4 {
-                let fneigh = self.get_forward_neighbor(i, j);
-                let fneigh_index = self.to_index(fneigh);
-                neighbors[2 * j] = fneigh_index;
-
-                let bneigh = self.get_backward_neighbor(i, j);
-                let bneigh_index = self.to_index(bneigh);
-                neighbors[2 * j + 1] = bneigh_index;
-            }
-
-            table.push(neighbors);
-        }
-
-        table
     }
 
     pub fn spacing(&self) -> f64 {

--- a/lqft/src/main.rs
+++ b/lqft/src/main.rs
@@ -15,7 +15,7 @@ use tracing_loki::url::Url;
 use tracing_subscriber::Layer;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
-use crate::observable_impl::{MeanValue, Variance};
+use crate::observable_impl::{ActionDensity, Mean, Variance};
 
 #[tokio::main]
 async fn main() -> ExitCode {
@@ -59,8 +59,9 @@ async fn app() -> anyhow::Result<()> {
         .with_performance(PerformanceDesc {
             lattice_iter: LatticeIterMethod::Parallel
         })
-        .with_observable::<MeanValue>()
+        .with_observable::<Mean>()
         .with_observable::<Variance>()
+        .with_observable::<ActionDensity>()
         .with_acceptance(AcceptanceDesc {
             correction_interval: 20_000,
             initial_step_size: 1.0,
@@ -76,7 +77,7 @@ async fn app() -> anyhow::Result<()> {
 
     // visual::plot_lattice(0, sim.lattice())?;
 
-    let total_sweeps = 50_000;
+    let total_sweeps = 1;
     sim.simulate_checkerboard(total_sweeps)?;
 
     // visual::plot_lattice(1, sim.lattice())?;

--- a/lqft/src/main.rs
+++ b/lqft/src/main.rs
@@ -17,25 +17,6 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use crate::observable_impl::{MeanValue, Variance};
 
-/// Makes all struct fields public in the current and specified modules.
-/// This makes it easier to spread implementation details over multiple archive.
-#[macro_export]
-macro_rules! all_public_in {
-    ($module:path, $vis:vis struct $name:ident {
-        $(
-            $(#[$meta:meta])*
-            $field_name:ident: $field_type:ty
-        ),* $(,)?
-    }) => {
-        $vis struct $name {
-            $(
-                $(#[$meta])*
-                pub(in $module) $field_name : $field_type
-            ),*
-        }
-    }
-}
-
 #[tokio::main]
 async fn main() -> ExitCode {
     if let Err(err) = app().await {

--- a/lqft/src/main.rs
+++ b/lqft/src/main.rs
@@ -9,7 +9,7 @@ mod stats;
 mod metrics;
 mod observable_impl;
 
-use crate::setup::{AcceptanceDesc, BurnInDesc, FlushMethod, InitialState, LatticeCreateDesc, LatticeDesc, LatticeIterMethod, LatticeLoadDesc, ParamDesc, PerformanceDesc, SnapshotDesc, SnapshotLocation, SnapshotType, SystemBuilder};
+use crate::setup::{AcceptanceDesc, BurnInDesc, InitialState, LatticeCreateDesc, LatticeDesc, LatticeIterMethod, ParamDesc, PerformanceDesc, SystemBuilder};
 use std::process::ExitCode;
 use tracing_loki::url::Url;
 use tracing_subscriber::Layer;
@@ -47,8 +47,6 @@ async fn main() -> ExitCode {
 }
 
 async fn app() -> anyhow::Result<()> {
-    assert!(is_x86_feature_detected!("avx"));
-
     let (layer, task) = tracing_loki::builder()
         .label("application", "lqft")?
         .label("env", "dev")?

--- a/lqft/src/metrics.rs
+++ b/lqft/src/metrics.rs
@@ -1,7 +1,6 @@
 use std::net::SocketAddr;
 use crate::sim::System;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{Ordering};
 
 // pub fn plot_lattice(index: usize, lattice: &Lattice) -> anyhow::Result<()> {
 //     let filename = format!("plots/step-{index}.png");
@@ -234,8 +233,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 //     Ok(())
 // }
 
-use prometheus::Encoder;
-use prometheus_exporter::Exporter;
 use prometheus_exporter::prometheus as ps;
 use crate::all_public_in;
 use crate::observable_impl::{MeanValue, Variance};
@@ -307,9 +304,6 @@ impl MetricState {
         let sweep_size = ps::register_int_counter!("sweep_size", "Sweep size")?;
 
         let runtime = ps::register_gauge!("run_time", "Run time")?;
-
-        let running = Arc::new(AtomicBool::new(true));
-        let clone = Arc::clone(&running);
 
         let addr: SocketAddr = "127.0.0.1:9184".parse()?;
         prometheus_exporter::start(addr).expect("Failed to start Prometheus exporter");

--- a/lqft/src/metrics.rs
+++ b/lqft/src/metrics.rs
@@ -1,5 +1,5 @@
 use std::net::SocketAddr;
-use crate::sim::System;
+use crate::{observable::ObservableHList, sim::System};
 use std::sync::atomic::{Ordering};
 
 // pub fn plot_lattice(index: usize, lattice: &Lattice) -> anyhow::Result<()> {
@@ -234,7 +234,6 @@ use std::sync::atomic::{Ordering};
 // }
 
 use prometheus_exporter::prometheus as ps;
-use crate::all_public_in;
 use crate::observable_impl::{MeanValue, Variance};
 
 pub fn set_int_to(ctr: &ps::IntCounter, new_value: u64) {
@@ -242,37 +241,34 @@ pub fn set_int_to(ctr: &ps::IntCounter, new_value: u64) {
     ctr.inc_by(inc);
 }
 
-all_public_in! {
-    super,
-    pub struct MetricState {
-        total_moves: ps::IntCounter,
-        accepted_moves: ps::IntCounter,
-        accept_ratio: ps::Gauge,
-        progress: ps::Gauge,
+pub struct MetricState {
+    pub total_moves: ps::IntCounter,
+    pub accepted_moves: ps::IntCounter,
+    pub accept_ratio: ps::Gauge,
+    pub progress: ps::Gauge,
 
-        step_size: ps::Gauge,
-        action_density: ps::Gauge,
-        performed_measurements: ps::IntCounter,
+    pub step_size: ps::Gauge,
+    pub action_density: ps::Gauge,
+    pub performed_measurements: ps::IntCounter,
 
-        sweep_time: ps::Gauge,
-        stats_time: ps::Gauge,
-        therm_ratio: ps::Gauge,
-        completed_sweeps: ps::IntCounter,
-        thermalised_at: ps::IntCounter,
+    pub sweep_time: ps::Gauge,
+    pub stats_time: ps::Gauge,
+    pub therm_ratio: ps::Gauge,
+    pub completed_sweeps: ps::IntCounter,
+    pub thermalised_at: ps::IntCounter,
 
-        mean: ps::Gauge,
-        meansq: ps::Gauge,
-        var: ps::Gauge,
+    pub mean: ps::Gauge,
+    pub meansq: ps::Gauge,
+    pub var: ps::Gauge,
 
-        cpu: ps::Gauge,
-        mem: ps::Gauge,
+    pub cpu: ps::Gauge,
+    pub mem: ps::Gauge,
 
-        sys: sysinfo::System,
-        pid: sysinfo::Pid,
-        pid_ctr: ps::IntCounter,
-        runtime: ps::Gauge,
-        sweep_size: ps::IntCounter
-    }
+    pub sys: sysinfo::System,
+    pub pid: sysinfo::Pid,
+    pub pid_ctr: ps::IntCounter,
+    pub runtime: ps::Gauge,
+    pub sweep_size: ps::IntCounter
 }
 
 impl MetricState {
@@ -330,7 +326,7 @@ impl MetricState {
     }
 }
 
-impl System {
+impl<T: ObservableHList> System<T> {
     pub fn push_metrics(&mut self) {
         let sweep_size = self.lattice().sweep_size();
 

--- a/lqft/src/metrics.rs
+++ b/lqft/src/metrics.rs
@@ -234,7 +234,7 @@ use std::sync::atomic::{Ordering};
 // }
 
 use prometheus_exporter::prometheus as ps;
-use crate::observable_impl::{MeanValue, Variance};
+use crate::observable_impl::{ActionDensity, Mean, Variance};
 
 pub fn set_int_to(ctr: &ps::IntCounter, new_value: u64) {
     let inc = new_value - ctr.get();
@@ -328,10 +328,9 @@ impl MetricState {
 
 impl<T: ObservableHList> System<T> {
     pub fn push_metrics(&mut self) {
-        let sweep_size = self.lattice().sweep_size();
-
-        self.measured::<MeanValue>().inspect(|&v| self.metrics.mean.set(v));
+        self.measured::<Mean>().inspect(|&v| self.metrics.mean.set(v));
         self.measured::<Variance>().inspect(|&v| self.metrics.var.set(v));
+        self.measured::<ActionDensity>().inspect(|&v| self.metrics.action_density.set(v));
 
         let metrics = &mut self.metrics;
 
@@ -345,7 +344,6 @@ impl<T: ObservableHList> System<T> {
         metrics.progress.set(progress);
 
         metrics.step_size.set(self.data.current_step_size.load(Ordering::Relaxed));
-        metrics.action_density.set(self.data.stats.current_action / sweep_size as f64);
 
         set_int_to(&metrics.performed_measurements, self.data.stats.performed_measurements as u64);
 

--- a/lqft/src/observable.rs
+++ b/lqft/src/observable.rs
@@ -1,120 +1,147 @@
 //! Implements the observable API.
 
-use rayon::prelude::*;
-
 use std::any::{Any, TypeId};
-use std::collections::HashMap;
-use std::hash::{BuildHasherDefault};
-use nohash_hasher::NoHashHasher;
+use std::marker::PhantomData;
 use crate::sim::SystemData;
 
-pub struct ObservableRegistry {
-    map: HashMap<TypeId, Box<dyn ObservableState>, BuildHasherDefault<NoHashHasher<u64>>>,
+pub trait ObservableHList {
+    fn new() -> Self;
+    fn has<O: Observable>() -> bool;
+    fn observe(&mut self, system: &SystemData);
+    fn measured<O: Observable>(&self) -> Option<O::Output>;
+    fn reserve(&mut self, n: usize);
 }
 
-impl ObservableRegistry {
-    /// Creates a new observable storage.
+impl ObservableHList for () {
+    fn new() -> () {}
+
+    fn has<O: Observable>() -> bool { 
+        false 
+    }
+
+    fn observe(&mut self, _system: &SystemData) {}
+
+    fn measured<O: Observable>(&self) -> Option<O::Output> {
+        panic!("Observable {} is not registered.", O::NAME);
+    }
+
+    fn reserve(&mut self, _n: usize) {}
+}
+
+impl<O1: Observable> ObservableHList for O1 {
+    fn new() -> O1 { <O1 as Observable>::new() }
+
+    fn has<O: Observable>() -> bool { 
+        TypeId::of::<O>() == TypeId::of::<O1>() 
+    }
+
+    fn observe(&mut self, system: &SystemData) {
+        <O1 as Observable>::observe(self, system);
+    }
+
+    fn measured<O: Observable>(&self) -> Option<O::Output> {
+        if !Self::has::<O>() {
+            None
+        } else {
+            let latest = self.latest();
+
+            assert_eq!(TypeId::of::<O1::Output>(), TypeId::of::<O::Output>(), "Measured and requested type are not equal. This is a bug.");
+            
+            let any = latest
+                .as_ref()
+                .map(|x| (x as &dyn Any).downcast_ref::<O::Output>())
+                .flatten();
+
+            any.cloned()
+        }
+    }
+
+    fn reserve(&mut self, n: usize) {
+        <Self as Observable>::reserve(self, n);
+    }
+}
+
+impl<OL: ObservableHList, O1: Observable> ObservableHList for (OL, O1) {
+    fn new() -> (OL, O1) {
+        (OL::new(), <O1 as Observable>::new())
+    }
+
+    fn has<O: Observable>() -> bool { 
+        TypeId::of::<O>() == TypeId::of::<O1>() || OL::has::<O>()
+    }
+
+    fn observe(&mut self, system: &SystemData) {
+        <O1 as Observable>::observe(&mut self.1, system);
+        OL::observe(&mut self.0, system);
+    }
+
+    fn measured<O: Observable>(&self) -> Option<O::Output> {
+        if O1::has::<O>() {
+            O1::measured::<O>(&self.1)
+        } else {
+            OL::measured::<O>(&self.0)
+        }
+    }
+
+    fn reserve(&mut self, n: usize) {
+        <O1 as Observable>::reserve(&mut self.1, n);
+        <OL as ObservableHList>::reserve(&mut self.0, n);
+    }
+}
+
+pub struct ObservableBuilder<Obs: ObservableHList> {
+    _marker: PhantomData<Obs>
+}
+
+impl ObservableBuilder<()> {
     pub fn new() -> Self {
-        Self {
-            map: HashMap::with_hasher(BuildHasherDefault::<NoHashHasher<u64>>::default()),
-        }
-    }
-
-    pub fn measure(&mut self, data: &SystemData) {
-        self.map.par_iter_mut().for_each(|(_k, v)| {
-            if v.should_measure(data) {
-                v.measure(data);
-            }
-        })
-    }
-
-    pub fn register<O: Observable>(&mut self) {
-        self.map.insert(TypeId::of::<O>(), Box::new(O::new_state()));
-    }
-
-    /// Retrieves the state of the given observable.
-    pub fn get<O: Observable>(&self) -> Option<&O::State> {
-        self.map.get(&TypeId::of::<O>()).map(|boxed| {
-            boxed.as_any().downcast_ref::<O::State>()
-        }).flatten()
-    }
-
-    // /// Mutably retrieves the state of the given observable.
-    // pub fn get_mut<O: Observable>(&mut self) -> Option<&mut O::State> {
-    //     self.map.get_mut(&TypeId::of::<O>()).map(|boxed| {
-    //         boxed.as_any_mut().downcast_mut::<O::State>()
-    //     }).flatten()
-    // }
-
-    /// Retrieves the last measured value of the observable.
-    pub fn measured<O: Observable>(&self) -> Option<f64> {
-        let obs = self.get::<O>()?;
-        obs.measured()
+        ObservableBuilder { _marker: PhantomData }
     }
 }
 
-/// When to perform measurements.
-pub enum MeasureFrequency {
-    Once,
-    /// Every `n` autocorrelation times.
-    Autocorrelation(usize),
-    /// Every `n` sweeps.
-    Sweep(usize)
-}
+impl<Obs: ObservableHList> ObservableBuilder<Obs> {
+    pub fn has<O: Observable>(&self) -> bool {
+        Obs::has::<O>()
+    }
 
-// trait AsAny: Any {
-//     fn as_any(&self) -> &dyn Any;
-//     fn as_any_mut(&mut self) -> &mut dyn Any;
-// }
-//
-// impl<T: Any> AsAny for T {
-//     fn as_any(&self) -> &dyn Any { self }
-//     fn as_any_mut(&mut self) -> &mut dyn Any { self }
-// }
-
-/// Information specific to certain measurement types.
-pub trait ObservableState: Send + Sync + 'static {
-    fn as_any(&self) -> &dyn Any;
-
-    /// Approximate frequency of measurements.
-    fn frequency(&self) -> MeasureFrequency;
-    /// Whether this observable requires thermalisation.
-    fn burn_in(&self) -> bool { true }
-
-    /// Makes a new measurement.
-    fn measure(&mut self, data: &SystemData);
-
-    /// Determines whether the observables should be measured.
-    ///
-    /// By default this follows the frequency defined in [`FREQUENCY`](Self::FREQUENCY).
-    fn should_measure(&self, data: &SystemData) -> bool {
-        if self.burn_in() && !data.stats.thermalised_at.is_some() {
-            return false
-        }
-
-        match self.frequency() {
-            MeasureFrequency::Autocorrelation(_) => todo!(),
-            MeasureFrequency::Sweep(n) => data.stats.current_sweep % n == 0,
-            MeasureFrequency::Once => panic!("One-time observables should have a custom `should_measure` implementation")
+    pub fn with<O: Observable>(self) -> ObservableBuilder<(Obs, O)> {
+        ObservableBuilder {
+            _marker: PhantomData
         }
     }
 
-    /// Returns the last measured quantity.
-    fn measured(&self) -> Option<f64>;
+    pub fn build(self) -> ObservableStorage<Obs> {
+        ObservableStorage {
+            storage: Obs::new()
+        }
+    }
+}
 
-    /// Clears the observable's state.
-    fn clear(&mut self);
+pub struct ObservableStorage<Obs> {
+    storage: Obs
+}
 
-    /// Prepares for `n` additional measurements. The number of measurements is an estimate based
-    /// on [`FREQUENCY`](Self::FREQUENCY).
-    fn prepare(&mut self, n: usize);
+impl<Obs: ObservableHList> ObservableStorage<Obs> {
+    pub fn has<O: Observable>(&self) -> bool {
+        Obs::has::<O>()
+    }
+
+    pub fn observe_all(&mut self, data: &SystemData) {
+        self.storage.observe(data);
+    }
+
+    pub fn measured<O: Observable>(&self) -> Option<O::Output> {
+        self.storage.measured::<O>()
+    }
 }
 
 pub trait Observable: 'static {
-    type State: ObservableState;
+    type Output: Clone + 'static;
 
-    /// Name of the observable.
     const NAME: &'static str;
 
-    fn new_state() -> Self::State;
+    fn new() -> Self;
+    fn reserve(&mut self, n: usize);
+    fn observe(&mut self, system: &SystemData);
+    fn latest(&self) -> Option<Self::Output>;
 }

--- a/lqft/src/observable.rs
+++ b/lqft/src/observable.rs
@@ -1,18 +1,49 @@
 //! Implements the observable API.
 
 use std::any::{Any, TypeId};
+use std::fmt;
+use std::fmt::Debug;
 use std::marker::PhantomData;
 use crate::sim::SystemData;
 
-pub trait ObservableHList {
+/// A list of different observables.
+pub trait ObservableHList: 'static {
+    /// The amount of observables in this list.
+    const LEN: usize;
+
+    /// Creates a new empty list.
     fn new() -> Self;
+
+    /// Determines whether an observable is in the list.
     fn has<O: Observable>() -> bool;
+
+    /// Collects data for all observables.
     fn observe(&mut self, system: &SystemData);
+
+    /// Returns the measurement history for the given observable.
+    ///
+    /// This function panics if the given observable is not in the list.
+    fn history<O: Observable>(&self) -> &[O::Output];
+
+    /// Returns the last measured result for the given observable.
+    /// 
+    /// This function returns `None` if the observable has produced no measurements yet, or
+    /// the observable is not in the list.
     fn measured<O: Observable>(&self) -> Option<O::Output>;
+
+    /// Reserves capacity for an additional `n` measurements.
     fn reserve(&mut self, n: usize);
+
+    /// Retrieves the state.
+    fn state<O: Observable>(&self) -> &O;
+
+    /// Retrieves the state mutably.
+    fn state_mut<O: Observable>(&mut self) -> &mut O;
 }
 
 impl ObservableHList for () {
+    const LEN: usize = 0;
+
     fn new() -> () {}
 
     fn has<O: Observable>() -> bool { 
@@ -21,14 +52,28 @@ impl ObservableHList for () {
 
     fn observe(&mut self, _system: &SystemData) {}
 
+    fn history<O: Observable>(&self) -> &[O::Output] {
+        panic!("Cannot retrieve history. Observable \"{}\" is not registered. Register it using `SystemBuilder::with_observable`", O::NAME);
+    }
+
     fn measured<O: Observable>(&self) -> Option<O::Output> {
-        panic!("Observable {} is not registered.", O::NAME);
+        panic!("Cannot retrieve last measurement. Observable \"{}\" is not registered. Register it using `SystemBuilder::with_observable.`", O::NAME);
     }
 
     fn reserve(&mut self, _n: usize) {}
+
+    fn state<O: Observable>(&self) -> &O {
+        panic!("Cannot retrieve observable state. Observable \"{}\" is not registered. Register it using `SystemBuilder::with_observable`.", O::NAME);
+    }
+
+    fn state_mut<O: Observable>(&mut self) -> &mut O {
+        panic!("Cannot retrieve observable state. Observable \"{}\" is not registered. Register it using `SystemBuilder::with_observable`.", O::NAME);
+    }
 }
 
 impl<O1: Observable> ObservableHList for O1 {
+    const LEN: usize = 1;
+
     fn new() -> O1 { <O1 as Observable>::new() }
 
     fn has<O: Observable>() -> bool { 
@@ -39,29 +84,44 @@ impl<O1: Observable> ObservableHList for O1 {
         <O1 as Observable>::observe(self, system);
     }
 
+    fn history<O: Observable>(&self) -> &[O::Output] {
+        if !Self::has::<O>() {
+            unreachable!("This path should not be reached. This is a bug");
+        } else {
+            let cast = (self as &dyn Any)
+                .downcast_ref::<O>()
+                .expect("O != O1, this is a bug. In O1");
+            <O as Observable>::history(cast)
+        }
+    }
+
     fn measured<O: Observable>(&self) -> Option<O::Output> {
         if !Self::has::<O>() {
-            None
+            unreachable!("This path should not be reached. This is a bug");
         } else {
-            let latest = self.latest();
-
-            assert_eq!(TypeId::of::<O1::Output>(), TypeId::of::<O::Output>(), "Measured and requested type are not equal. This is a bug.");
-            
-            let any = latest
-                .as_ref()
-                .map(|x| (x as &dyn Any).downcast_ref::<O::Output>())
-                .flatten();
-
-            any.cloned()
+            let cast = (self as &dyn Any)
+                .downcast_ref::<O>()
+                .expect("O != O1, this is a bug. In O1");
+            <O as Observable>::latest(cast)
         }
     }
 
     fn reserve(&mut self, n: usize) {
         <Self as Observable>::reserve(self, n);
     }
+
+    fn state<O: Observable>(&self) -> &O {
+        (self as &dyn Any).downcast_ref::<O>().expect("State cast failed. This is a bug.")
+    }
+
+    fn state_mut<O: Observable>(&mut self) -> &mut O {
+        (self as &mut dyn Any).downcast_mut::<O>().expect("State cast failed. This is a bug.")
+    }
 }
 
 impl<OL: ObservableHList, O1: Observable> ObservableHList for (OL, O1) {
+    const LEN: usize = 1 + OL::LEN;
+
     fn new() -> (OL, O1) {
         (OL::new(), <O1 as Observable>::new())
     }
@@ -73,6 +133,17 @@ impl<OL: ObservableHList, O1: Observable> ObservableHList for (OL, O1) {
     fn observe(&mut self, system: &SystemData) {
         <O1 as Observable>::observe(&mut self.1, system);
         OL::observe(&mut self.0, system);
+    }
+
+    fn history<O: Observable>(&self) -> &[O::Output] {
+        if O1::has::<O>() {
+            let cast = (&self.1 as &dyn Any)
+                .downcast_ref::<O>()
+                .expect("O1 != O, this is a bug. In (OL, O1)");
+            <O as Observable>::history(cast)
+        } else {
+            OL::history::<O>(&self.0)
+        }
     }
 
     fn measured<O: Observable>(&self) -> Option<O::Output> {
@@ -87,61 +158,175 @@ impl<OL: ObservableHList, O1: Observable> ObservableHList for (OL, O1) {
         <O1 as Observable>::reserve(&mut self.1, n);
         <OL as ObservableHList>::reserve(&mut self.0, n);
     }
+
+    fn state<O: Observable>(&self) -> &O {
+        if O1::has::<O>() {
+            (self as &dyn Any).downcast_ref::<O>().expect("State cast failed. This is a bug.")
+        } else {
+            OL::state::<O>(&self.0)
+        }
+    }
+
+    fn state_mut<O: Observable>(&mut self) -> &mut O {
+        if O1::has::<O>() {
+            (self as &mut dyn Any).downcast_mut::<O>().expect("State cast failed. This is a bug.")
+        } else {
+            OL::state_mut::<O>(&mut self.0)
+        }
+    }
 }
 
+/// Collects observables to create an [`ObservableStore`].
 pub struct ObservableBuilder<Obs: ObservableHList> {
     _marker: PhantomData<Obs>
 }
 
 impl ObservableBuilder<()> {
+    /// Creates a new empty observable builder.
     pub fn new() -> Self {
         ObservableBuilder { _marker: PhantomData }
     }
 }
 
 impl<Obs: ObservableHList> ObservableBuilder<Obs> {
+    /// Determines whether the builder contains the given observable.
     pub fn has<O: Observable>(&self) -> bool {
         Obs::has::<O>()
     }
 
+    /// Determines the amount of observables in the builder.
+    pub const fn len(&self) -> usize {
+        Obs::LEN
+    }
+
+    /// Adds an observable to the builder.
     pub fn with<O: Observable>(self) -> ObservableBuilder<(Obs, O)> {
+        if self.has::<O>() {
+            panic!("Observable \"{}\" has already been registered.", O::NAME);
+        }
+
         ObservableBuilder {
             _marker: PhantomData
         }
     }
 
-    pub fn build(self) -> ObservableStorage<Obs> {
-        ObservableStorage {
+    /// Creates an observable storage from this builder.
+    pub fn build(self) -> ObservableStore<Obs> {
+        ObservableStore {
             storage: Obs::new()
         }
     }
 }
 
-pub struct ObservableStorage<Obs> {
+/// Stores observables and their associated data.
+/// 
+/// This uses the [`ObservableHList`] trait internally to store an arbitrary list of observable
+/// types in a single struct. Unlike the naive dynamic dispatch approach of using `Box<dyn Any>`, this
+/// method completely avoids dynamic dispatch by encoding the contents of the storage inside of the type at
+/// compile time. This means that the compiler will evaluate a lot of the code at compile time rather than
+/// runtime.
+pub struct ObservableStore<Obs: ObservableHList> {
+    // Originally wanted to implement `Debug` for this to easily print out observable values but it seems
+    // like this is impossible unless I require that every single observable is `Debug`.
+    //
+    // Treating `Debug` and non-`Debug` observables differently either requires specialisation
+    // (which is highly unstable) or autoref specialisation, which is stable but only work with
+    // concrete types, not the generics we are dealing with.
     storage: Obs
 }
 
-impl<Obs: ObservableHList> ObservableStorage<Obs> {
+impl<Obs: ObservableHList> ObservableStore<Obs> {
+    /// Determines whether the storage contains the given observable.
+    /// 
+    /// This function is entirely evaluated at compile time.
     pub fn has<O: Observable>(&self) -> bool {
         Obs::has::<O>()
     }
 
+    /// Determines the amount of observables in the storage.
+    pub const fn len(&self) -> usize {
+        Obs::LEN
+    }
+
+    /// Attemps to performs measurements for all observables.
+    #[inline]
     pub fn observe_all(&mut self, data: &SystemData) {
         self.storage.observe(data);
     }
 
+    /// Reserves capacity for `n` additional measurements.
+    #[inline]
+    pub fn reserve(&mut self, n: usize) {
+        self.storage.reserve(n);
+    }
+
+    /// Returns the measurement history for the given observables.
+    ///
+    /// This function panics if the given observable was not registered with the system at build time.
+    #[inline]
+    pub fn history<O: Observable>(&self) -> &[O::Output] {
+        self.storage.history::<O>()
+    }
+
+    /// Returns the last measurement for the given observable.
+    /// 
+    /// This function returns `None` if the observable has produced no measurements yet.
+    /// It panics if the given observable has not been registered with the system at build time.
+    #[inline]
     pub fn measured<O: Observable>(&self) -> Option<O::Output> {
         self.storage.measured::<O>()
     }
+
+    /// Retrieves the observable's state
+    ///
+    /// This function panics if the observable was not registered.
+    #[inline]
+    pub fn state<O: Observable>(&self) -> &O {
+        self.storage.state::<O>()
+    }
+
+    /// Retrieves a mutable reference to the state.
+    ///
+    /// This function panics if the observable was not registered.
+    #[inline]
+    pub fn state_mut<O: Observable>(&mut self) -> &mut O {
+        self.storage.state_mut::<O>()
+    }
 }
 
+impl<Obs: Clone + ObservableHList> Clone for ObservableStore<Obs> {
+    fn clone(&self) -> Self {
+        ObservableStore {
+            storage: self.storage.clone()
+        }
+    }
+}
+
+/// Represents an observable. This allows a struct to make arbitrary measurements of the system.
+/// 
+/// After thermalisation, the system will automatically collect several measurements to compute the
+/// autocorrelation time of the observable. When this is completed, the observable will only be measured
+/// every set autocorrelation times.
 pub trait Observable: 'static {
+    /// The data type of the measurements of this observable.
+    /// 
+    /// *Note*: ideally this should be a small type since it is cloned when it is accessed.
     type Output: Clone + 'static;
 
+    /// The name of the observable. This is used as the identifier in Prometheus metrics.
+    /// 
+    /// The name should not contain any spaces.
     const NAME: &'static str;
 
+    /// Creates a new empty observable.
     fn new() -> Self;
+    /// Reserves capacity for `n` additional measurements.
     fn reserve(&mut self, n: usize);
+    /// Performs a new measurement. This measurement is then stored internally to possibly be accessed
+    /// later.
     fn observe(&mut self, system: &SystemData);
+    /// Access all measurements.
+    fn history(&self) -> &[Self::Output];
+    /// Access the latest measurement of the observable.
     fn latest(&self) -> Option<Self::Output>;
 }

--- a/lqft/src/observable.rs
+++ b/lqft/src/observable.rs
@@ -6,7 +6,7 @@ use std::any::{Any, TypeId};
 use std::collections::HashMap;
 use std::hash::{BuildHasherDefault};
 use nohash_hasher::NoHashHasher;
-use crate::sim::{System, SystemData};
+use crate::sim::SystemData;
 
 pub struct ObservableRegistry {
     map: HashMap<TypeId, Box<dyn ObservableState>, BuildHasherDefault<NoHashHasher<u64>>>,
@@ -35,18 +35,16 @@ impl ObservableRegistry {
     /// Retrieves the state of the given observable.
     pub fn get<O: Observable>(&self) -> Option<&O::State> {
         self.map.get(&TypeId::of::<O>()).map(|boxed| {
-            let any = boxed.as_any();
             boxed.as_any().downcast_ref::<O::State>()
         }).flatten()
     }
 
-    /// Mutably retrieves the state of the given observable.
-    pub fn get_mut<O: Observable>(&mut self) -> Option<&mut O::State> {
-        self.map.get_mut(&TypeId::of::<O>()).map(|boxed| {
-            // boxed.as_any_mut().downcast_mut::<O::State>()
-            todo!()
-        }).flatten()
-    }
+    // /// Mutably retrieves the state of the given observable.
+    // pub fn get_mut<O: Observable>(&mut self) -> Option<&mut O::State> {
+    //     self.map.get_mut(&TypeId::of::<O>()).map(|boxed| {
+    //         boxed.as_any_mut().downcast_mut::<O::State>()
+    //     }).flatten()
+    // }
 
     /// Retrieves the last measured value of the observable.
     pub fn measured<O: Observable>(&self) -> Option<f64> {

--- a/lqft/src/observable_impl.rs
+++ b/lqft/src/observable_impl.rs
@@ -1,10 +1,9 @@
 //! Implementations of basic observables.
 
 use std::any::Any;
-use crate::observable::*;
 
 use crate::observable::{MeasureFrequency, Observable, ObservableState};
-use crate::sim::{System, SystemData};
+use crate::sim::SystemData;
 
 /// Measures the mean of the lattice.
 pub struct MeanValue;

--- a/lqft/src/observable_impl.rs
+++ b/lqft/src/observable_impl.rs
@@ -4,35 +4,41 @@ use crate::observable::{Observable};
 use crate::sim::SystemData;
 
 /// Measures the mean of the lattice.
-pub struct MeanValue {
-    data: Vec<f64>
+#[derive(Debug)]
+pub struct Mean {
+    history: Vec<f64>
 }
 
-impl Observable for MeanValue {
+impl Observable for Mean {
     type Output = f64;
 
     const NAME: &'static str = "mean";
 
     fn new() -> Self {
-        Self { data: Vec::new() }
+        Self { history: Vec::new() }
     }
 
     fn reserve(&mut self, n: usize) {
-        self.data.reserve(n);
+        self.history.reserve(n);
     }
 
     fn observe(&mut self, system: &SystemData) {
-        self.data.push(system.lattice.mean())
+        self.history.push(system.lattice.mean())
+    }
+
+    fn history(&self) -> &[f64] {
+        &self.history
     }
 
     fn latest(&self) -> Option<f64> {
-        self.data.last().copied()
+        self.history.last().copied()
     }
 }
 
 /// Measures the variance of the lattice.
+#[derive(Debug)]
 pub struct Variance {
-    data: Vec<f64>
+    history: Vec<f64>
 }
 
 impl Observable for Variance {
@@ -41,18 +47,55 @@ impl Observable for Variance {
     const NAME: &'static str = "variance";
 
     fn new() -> Variance {
-        Variance { data: Vec::new() }
+        Variance { history: Vec::new() }
     }
 
     fn reserve(&mut self, n: usize) {
-        self.data.reserve(n);
+        self.history.reserve(n);
     }
 
     fn observe(&mut self, system: &SystemData) {
-        self.data.push(system.lattice.variance());
+        self.history.push(system.lattice.variance());
+    }
+
+    fn history(&self) -> &[f64] {
+        &self.history
     }
 
     fn latest(&self) -> Option<f64> {
-        self.data.last().copied()
+        self.history.last().copied()
+    }
+}
+
+#[derive(Debug)]
+pub struct ActionDensity {
+    history: Vec<f64>
+}
+
+impl Observable for ActionDensity {
+    type Output = f64;
+
+    const NAME: &'static str = "action_density";
+
+    fn new() -> ActionDensity {
+        ActionDensity {
+            history: Vec::new()
+        }
+    }
+
+    fn reserve(&mut self, n: usize) {
+        self.history.reserve(n);
+    }
+
+    fn observe(&mut self, system: &SystemData) {
+        self.history.push(system.compute_full_action());
+    }
+
+    fn history(&self) -> &[f64] {
+        &self.history
+    }
+
+    fn latest(&self) -> Option<f64> {
+        self.history.last().copied()
     }
 }

--- a/lqft/src/observable_impl.rs
+++ b/lqft/src/observable_impl.rs
@@ -1,102 +1,58 @@
 //! Implementations of basic observables.
 
-use std::any::Any;
-
-use crate::observable::{MeasureFrequency, Observable, ObservableState};
+use crate::observable::{Observable};
 use crate::sim::SystemData;
 
 /// Measures the mean of the lattice.
-pub struct MeanValue;
-
-impl Observable for MeanValue {
-    type State = MeanValueState;
-
-    const NAME: &'static str = "mean_value";
-
-    fn new_state() -> Self::State {
-        MeanValueState { data: Vec::new() }
-    }
-}
-
-pub struct MeanValueState {
+pub struct MeanValue {
     data: Vec<f64>
 }
 
-impl ObservableState for MeanValueState {
-    fn as_any(&self) -> &dyn Any {
-        self
+impl Observable for MeanValue {
+    type Output = f64;
+
+    const NAME: &'static str = "mean";
+
+    fn new() -> Self {
+        Self { data: Vec::new() }
     }
 
-    fn frequency(&self) -> MeasureFrequency {
-        MeasureFrequency::Sweep(1)
-    }
-
-    fn burn_in(&self) -> bool {
-        false
-    }
-
-    fn measure(&mut self, data: &SystemData) {
-        let mean = data.lattice.mean_seq();
-        self.data.push(mean);
-    }
-
-    fn measured(&self) -> Option<f64> {
-        self.data.last().copied()
-    }
-
-    fn clear(&mut self) {
-        self.data.clear();
-    }
-
-    fn prepare(&mut self, n: usize) {
+    fn reserve(&mut self, n: usize) {
         self.data.reserve(n);
+    }
+
+    fn observe(&mut self, system: &SystemData) {
+        self.data.push(system.lattice.mean())
+    }
+
+    fn latest(&self) -> Option<f64> {
+        self.data.last().copied()
     }
 }
 
 /// Measures the variance of the lattice.
-pub struct Variance;
-
-impl Observable for Variance {
-    type State = VarianceState;
-
-    const NAME: &'static str = "variance";
-
-    fn new_state() -> Self::State {
-        VarianceState { data: Vec::new() }
-    }
-}
-
-pub struct VarianceState {
+pub struct Variance {
     data: Vec<f64>
 }
 
-impl ObservableState for VarianceState {
-    fn as_any(&self) -> &dyn Any {
-        self
+impl Observable for Variance {
+    type Output = f64;
+
+    const NAME: &'static str = "variance";
+
+    fn new() -> Variance {
+        Variance { data: Vec::new() }
     }
 
-    fn frequency(&self) -> MeasureFrequency {
-        MeasureFrequency::Sweep(1)
-    }
-
-    fn burn_in(&self) -> bool {
-        false
-    }
-
-    fn measure(&mut self, data: &SystemData) {
-        let mean = data.lattice.variance();
-        self.data.push(mean);
-    }
-
-    fn measured(&self) -> Option<f64> {
-        self.data.last().copied()
-    }
-
-    fn clear(&mut self) {
-        self.data.clear();
-    }
-
-    fn prepare(&mut self, n: usize) {
+    fn reserve(&mut self, n: usize) {
         self.data.reserve(n);
+    }
+
+    fn observe(&mut self, system: &SystemData) {
+        self.data.push(system.lattice.variance());
+    }
+
+    fn latest(&self) -> Option<f64> {
+        self.data.last().copied()
     }
 }

--- a/lqft/src/setup.rs
+++ b/lqft/src/setup.rs
@@ -9,11 +9,11 @@ use hdf5_metno as hdf5;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::{ops::Range, sync::atomic::Ordering, time::UNIX_EPOCH};
-use crate::observable::{Observable, ObservableRegistry};
+use crate::observable::{Observable, ObservableBuilder, ObservableHList};
 use crate::sim::SystemData;
 use crate::metrics::MetricState;
 
-impl System {
+impl<T: ObservableHList> System<T> {
     /// Determines whether thermalisation of the system has finished.
     ///
     /// This is done by averaging the action of a block of the last `th_block_size` sweeps
@@ -342,9 +342,9 @@ impl Default for ParamDesc {
 }
 
 /// Used to configure a lattice simulation.
-pub struct SystemBuilder {
+pub struct SystemBuilder<Obs: ObservableHList> {
     performance_desc: PerformanceDesc,
-    observables: ObservableRegistry,
+    observables: ObservableBuilder<Obs>,
     param_desc: ParamDesc,
     lattice_desc: LatticeDesc,
     acceptance_desc: AcceptanceDesc,
@@ -352,11 +352,11 @@ pub struct SystemBuilder {
     snapshot: Option<SnapshotDesc>,
 }
 
-impl SystemBuilder {
+impl SystemBuilder<()> {
     /// Creates a new system builder with default configuration.
     pub fn new() -> Self {
         Self {
-            observables: ObservableRegistry::new(),
+            observables: ObservableBuilder::new(),
             snapshot: None,
             lattice_desc: LatticeDesc::Create(LatticeCreateDesc::default()),
             param_desc: ParamDesc::default(),
@@ -365,7 +365,9 @@ impl SystemBuilder {
             performance_desc: PerformanceDesc::default()
         }
     }
+}
 
+impl<T: ObservableHList> SystemBuilder<T> {
     /// Enables snapshots using the given configuration.
     ///
     /// Snapshots are disabled by default.
@@ -384,9 +386,16 @@ impl SystemBuilder {
         self
     }
 
-    pub fn with_observable<O: Observable>(mut self) -> Self {
-        self.observables.register::<O>();
-        self
+    pub fn with_observable<O: Observable>(self) -> SystemBuilder<(T, O)> {
+        SystemBuilder {
+            observables: self.observables.with::<O>(),
+            acceptance_desc: self.acceptance_desc,
+            burn_in_desc: self.burn_in_desc,
+            lattice_desc: self.lattice_desc,
+            param_desc: self.param_desc,
+            performance_desc: self.performance_desc,
+            snapshot: self.snapshot
+        }
     }
 
     /// Sets the configuration for burn in.
@@ -430,7 +439,7 @@ impl SystemBuilder {
     }
 
     /// Creates the simulation using the given options.
-    pub fn build(self) -> anyhow::Result<System> {
+    pub fn build(self) -> anyhow::Result<System<T>> {
         tracing::info!("Finished configuration, building simulation...");
 
         if let LatticeDesc::Create(desc) = &self.lattice_desc {
@@ -490,8 +499,6 @@ impl SystemBuilder {
             current_step_size: AtomicF64::new(self.acceptance_desc.initial_step_size),
             acceptance_desc: self.acceptance_desc,
             burn_in_desc: self.burn_in_desc,
-            correlation_slices: Vec::new(),
-            measurement_interval: 50,
             stats: SystemStats::default(),
             successful_therm_checks: 0,
 
@@ -500,10 +507,10 @@ impl SystemBuilder {
 
         let mut sim = System {
             data,
-            observables: self.observables,
-            simulating: AtomicBool::new(false),
+            observables: self.observables.build(),
+            simulating: false,
             metrics: MetricState::new()?,
-            snapshot_state,
+            snapshot: snapshot_state,
         };
 
         let first_action = sim.compute_full_action();
@@ -518,7 +525,7 @@ impl SystemBuilder {
     }
 }
 
-impl Default for SystemBuilder {
+impl Default for SystemBuilder<()> {
     fn default() -> Self {
         Self::new()
     }

--- a/lqft/src/setup.rs
+++ b/lqft/src/setup.rs
@@ -7,11 +7,11 @@ use anyhow::Context;
 use atomic_float::AtomicF64;
 use hdf5_metno as hdf5;
 use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
 use std::{ops::Range, sync::atomic::Ordering, time::UNIX_EPOCH};
 use crate::observable::{Observable, ObservableBuilder, ObservableHList};
 use crate::sim::SystemData;
 use crate::metrics::MetricState;
+use crate::observable_impl::ActionDensity;
 
 impl<T: ObservableHList> System<T> {
     /// Determines whether thermalisation of the system has finished.
@@ -24,7 +24,7 @@ impl<T: ObservableHList> System<T> {
     pub fn compute_burn_in_ratio(&self) -> (f64, bool) {
         let bsize = self.th_block_size();
 
-        let action_history = &self.stats().action_history;
+        let action_history = &self.observables.history::<ActionDensity>();
         let ah_len = action_history.len();
         if ah_len < 2 * bsize {
             return (0.0, false);
@@ -374,6 +374,7 @@ impl<T: ObservableHList> SystemBuilder<T> {
     ///
     /// See [`SnapshotDesc`] for more information.
     pub fn enable_snapshot(mut self, desc: SnapshotDesc) -> Self {
+        tracing::info!("Enabled snapshots, saving to {}", desc.file);
         self.snapshot = Some(desc);
         self
     }
@@ -387,6 +388,7 @@ impl<T: ObservableHList> SystemBuilder<T> {
     }
 
     pub fn with_observable<O: Observable>(self) -> SystemBuilder<(T, O)> {
+        tracing::info!("Added observable \"{}\", measuring type {}", O::NAME, std::any::type_name::<O::Output>());
         SystemBuilder {
             observables: self.observables.with::<O>(),
             acceptance_desc: self.acceptance_desc,
@@ -440,6 +442,7 @@ impl<T: ObservableHList> SystemBuilder<T> {
 
     /// Creates the simulation using the given options.
     pub fn build(self) -> anyhow::Result<System<T>> {
+        tracing::info!("System is using {} observables.", T::LEN);
         tracing::info!("Finished configuration, building simulation...");
 
         if let LatticeDesc::Create(desc) = &self.lattice_desc {
@@ -505,17 +508,13 @@ impl<T: ObservableHList> SystemBuilder<T> {
             autocorrelation_samples: Vec::new()
         };
 
-        let mut sim = System {
+        let sim = System {
             data,
             observables: self.observables.build(),
             simulating: false,
             metrics: MetricState::new()?,
             snapshot: snapshot_state,
         };
-
-        let first_action = sim.compute_full_action();
-        sim.data.stats.current_action = first_action;
-        sim.data.stats.action_history.push(first_action);
 
         sim.metrics.sweep_size.inc_by(sim.data.lattice.sweep_size() as u64);
 

--- a/lqft/src/setup.rs
+++ b/lqft/src/setup.rs
@@ -329,7 +329,7 @@ pub struct ParamDesc {
     /// The coupling constant of the theory.
     pub coupling: f64,
     /// The squared mass of the field.
-    pub mass_squared: f64,
+    pub mass_squared: f64
 }
 
 impl Default for ParamDesc {
@@ -493,7 +493,9 @@ impl SystemBuilder {
             correlation_slices: Vec::new(),
             measurement_interval: 50,
             stats: SystemStats::default(),
-            successful_therm_checks: 0
+            successful_therm_checks: 0,
+
+            autocorrelation_samples: Vec::new()
         };
 
         let mut sim = System {

--- a/lqft/src/sim.rs
+++ b/lqft/src/sim.rs
@@ -1,5 +1,5 @@
 use crate::lattice::Lattice;
-use crate::observable_impl::MeanValue;
+use crate::observable_impl::Mean;
 use crate::setup::{AcceptanceDesc, BurnInDesc};
 use crate::snapshot::{SnapshotState};
 use crate::stats::SystemStats;
@@ -15,7 +15,7 @@ use std::simd::prelude::SimdPartialOrd;
 use std::sync::atomic::Ordering;
 use std::time::Instant;
 use rand::RngExt;
-use crate::observable::{Observable, ObservableHList, ObservableStorage};
+use crate::observable::{Observable, ObservableHList, ObservableStore};
 use crate::metrics::MetricState;
 
 const LANES: usize = 4;
@@ -61,7 +61,7 @@ pub struct System<O: ObservableHList> {
     pub simulating: bool,
     pub metrics: MetricState,
     pub snapshot: Option<SnapshotState>,
-    pub observables: ObservableStorage<O>,
+    pub observables: ObservableStore<O>,
     pub data: SystemData
 }
 
@@ -220,11 +220,6 @@ impl<T: ObservableHList> System<T> {
     pub fn simulate_checkerboard(&mut self, total_sweeps: usize) -> anyhow::Result<()> {
         self.data.stats.desired_sweeps = total_sweeps;
 
-        let action = self.compute_full_action();
-        self.data.stats.current_action = action;
-
-        tracing::debug!("Starting action is: {action}");
-
         if let Some(state) = &mut self.snapshot {
             state.init(self.data.lattice.dimensions(), total_sweeps)?;
         }
@@ -299,12 +294,6 @@ impl<T: ObservableHList> System<T> {
             let sweep_time = sweep_timer.elapsed();
             sweep_timer = Instant::now();
 
-            if i % 100 == 0 {
-                // Recalculate total action
-                let action = self.compute_full_action();
-                self.data.stats.current_action = action;
-            }
-
             // Keep track of thermalisation ratio.
             let (th_ratio, thermalised) = self.compute_burn_in_ratio();
             if i > 2 * self.data.burn_in_desc.block_size {
@@ -314,7 +303,9 @@ impl<T: ObservableHList> System<T> {
                 if i % self.data.burn_in_desc.block_size == 0 && self.data.stats.thermalised_at.is_none() {
                     if thermalised {
                         self.data.successful_therm_checks += 1;
+                        tracing::info!("System passed {} successive thermalisation checks", self.data.successful_therm_checks);
                     } else {
+                        tracing::info!("System failed thermalisation check, resetting counter");
                         self.data.successful_therm_checks = 0;
                     }
 
@@ -335,7 +326,7 @@ impl<T: ObservableHList> System<T> {
             } else {
                 // Store samples to estimate autocorrelation time.
                 // self.data.autocorrelation_samples.push(self.lattice().mean());
-                self.data.autocorrelation_samples.push(self.observables.measured::<MeanValue>().unwrap_or(0.0));
+                self.data.autocorrelation_samples.push(self.observables.measured::<Mean>().unwrap_or(0.0));
                 // self.data.autocorrelation_samples.push(self.compute_full_action());
             }
 
@@ -388,111 +379,8 @@ impl<T: ObservableHList> System<T> {
         self.observables.measured::<U>()
     }
 
-    pub fn observables(&self) -> &ObservableStorage<T> {
+    pub fn observables(&self) -> &ObservableStore<T> {
         &self.observables
-    }
-
-    /// Computes the autocorrelation time of the system in its current state.
-    fn compute_autocorrelation(&self) -> f64 {
-        todo!()
-    }
-
-    /// Computes the absolute action of the entire lattice.
-    pub fn compute_full_action(&self) -> f64 {
-        // TODO: Add sequential version
-
-        let msquared = f64x4::splat(self.mass_squared());
-        let coupling = f64x4::splat(self.coupling());
-        let spacing = f64x4::splat(self.lattice().spacing());
-        let a4 = spacing * spacing * spacing * spacing;
-        let div_a = f64x4::splat(1.0) / spacing;
-        let dims = self.lattice().dimensions();
-
-        // Compute action for red sites
-
-        let black_sites = &self.lattice().black_sites;
-        let action_red = self
-            .data.lattice.red_sites
-            .par_chunks(8)
-            .enumerate()
-            .map(|(i, chunk)| {
-                let site_vals = f64x4::from_slice(chunk);
-                let site_idxs = (usizex4::splat(i) + CTR) * TWO;
-
-                let mut der_sum = f64x4::splat(0.0);
-                for i in 0..4 {
-                    let fneigh_idxs = find_fneighbors(site_idxs, dims, i);
-                    // let bneigh_idxs = find_bneighbors(site_idxs, dims, i);
-
-                    let fneigh_vals = f64x4::gather_or_default(black_sites, fneigh_idxs / TWO);
-                    // let bneigh_vals = f64x4::gather_or_default(black_sites, bneigh_idxs / TWO);
-
-                    let f1_sqrt = (fneigh_vals - site_vals) * div_a;
-                    // let b1_sqrt = (site_vals - bneigh_vals) * div_a;
-
-                    der_sum += f1_sqrt * f1_sqrt;
-                }
-
-                const HALF: f64x4 = f64x4::splat(0.5);
-                const TFOURTH: f64x4 = f64x4::splat(1.0 / 24.0);
-
-                let site_vals2 = site_vals * site_vals;
-                let site_vals4 = site_vals2 * site_vals2;
-
-                let kinetic = HALF * der_sum;
-                let mass = HALF * msquared * site_vals2;
-                let inter = TFOURTH * coupling * site_vals4;
-
-                a4 * (kinetic + mass + inter)
-            })
-            .reduce(
-                || f64x4::splat(0.0),
-                |a, b| a + b
-            )
-            .reduce_sum();
-
-        let red_sites = &self.lattice().red_sites;
-        let action_black = self
-            .data.lattice.black_sites
-            .par_chunks(8)
-            .enumerate()
-            .map(|(i, chunk)| {
-                let site_vals = f64x4::from_slice(chunk);
-                let site_idxs = (usizex4::splat(i) + CTR) * TWO;
-
-                let mut der_sum = f64x4::splat(0.0);
-                for i in 0..4 {
-                    let fneigh_idxs = find_fneighbors(site_idxs, dims, i);
-                    // let bneigh_idxs = find_bneighbors(site_idxs, dims, i);
-
-                    let fneigh_vals = f64x4::gather_or_default(red_sites, fneigh_idxs / TWO);
-                    // let bneigh_vals = f64x4::gather_or_default(red_sites, bneigh_idxs / TWO);
-
-                    let f1_sqrt = (fneigh_vals - site_vals) * div_a;
-                    // let b1_sqrt = (site_vals - bneigh_vals) * div_a;
-
-                    der_sum += f1_sqrt * f1_sqrt
-                }
-
-                const HALF: f64x4 = f64x4::splat(0.5);
-                const TFOURTH: f64x4 = f64x4::splat(1.0 / 24.0);
-
-                let site_vals2 = site_vals * site_vals;
-                let site_vals4 = site_vals2 * site_vals2;
-
-                let kinetic = HALF * der_sum;
-                let mass = HALF * msquared * site_vals2;
-                let inter = TFOURTH * coupling * site_vals4;
-
-                a4 * (kinetic + mass + inter)
-            })
-            .reduce(
-                || f64x4::splat(0.0),
-                |a, b| a + b
-            )
-            .reduce_sum();
-
-        action_red + action_black
     }
 
     /// The current statistics of the simulation.
@@ -539,4 +427,105 @@ impl<T: ObservableHList> System<T> {
     pub fn thermalised(&self) -> bool {
         self.data.stats.thermalised_at.is_some()
     }
+}
+
+impl SystemData {
+    /// Computes the absolute action of the entire lattice.
+    pub fn compute_full_action(&self) -> f64 {
+        // TODO: Add sequential version
+
+        let msquared = f64x4::splat(self.mass_squared);
+        let coupling = f64x4::splat(self.coupling);
+        let spacing = f64x4::splat(self.lattice.spacing());
+        let a4 = spacing * spacing * spacing * spacing;
+        let div_a = f64x4::splat(1.0) / spacing;
+        let dims = self.lattice.dimensions();
+
+        // Compute action for red sites
+
+        let black_sites = &self.lattice.black_sites;
+        let action_red = self
+            .lattice.red_sites
+            .par_chunks(8)
+            .enumerate()
+            .map(|(i, chunk)| {
+                let site_vals = f64x4::from_slice(chunk);
+                let site_idxs = (usizex4::splat(i) + CTR) * TWO;
+
+                let mut der_sum = f64x4::splat(0.0);
+                for i in 0..4 {
+                    let fneigh_idxs = find_fneighbors(site_idxs, dims, i);
+                    // let bneigh_idxs = find_bneighbors(site_idxs, dims, i);
+
+                    let fneigh_vals = f64x4::gather_or_default(black_sites, fneigh_idxs / TWO);
+                    // let bneigh_vals = f64x4::gather_or_default(black_sites, bneigh_idxs / TWO);
+
+                    let f1_sqrt = (fneigh_vals - site_vals) * div_a;
+                    // let b1_sqrt = (site_vals - bneigh_vals) * div_a;
+
+                    der_sum += f1_sqrt * f1_sqrt;
+                }
+
+                const HALF: f64x4 = f64x4::splat(0.5);
+                const TFOURTH: f64x4 = f64x4::splat(1.0 / 24.0);
+
+                let site_vals2 = site_vals * site_vals;
+                let site_vals4 = site_vals2 * site_vals2;
+
+                let kinetic = HALF * der_sum;
+                let mass = HALF * msquared * site_vals2;
+                let inter = TFOURTH * coupling * site_vals4;
+
+                a4 * (kinetic + mass + inter)
+            })
+            .reduce(
+                || f64x4::splat(0.0),
+                |a, b| a + b
+            )
+            .reduce_sum();
+
+        let red_sites = &self.lattice.red_sites;
+        let action_black = self
+            .lattice.black_sites
+            .par_chunks(8)
+            .enumerate()
+            .map(|(i, chunk)| {
+                let site_vals = f64x4::from_slice(chunk);
+                let site_idxs = (usizex4::splat(i) + CTR) * TWO;
+
+                let mut der_sum = f64x4::splat(0.0);
+                for i in 0..4 {
+                    let fneigh_idxs = find_fneighbors(site_idxs, dims, i);
+                    // let bneigh_idxs = find_bneighbors(site_idxs, dims, i);
+
+                    let fneigh_vals = f64x4::gather_or_default(red_sites, fneigh_idxs / TWO);
+                    // let bneigh_vals = f64x4::gather_or_default(red_sites, bneigh_idxs / TWO);
+
+                    let f1_sqrt = (fneigh_vals - site_vals) * div_a;
+                    // let b1_sqrt = (site_vals - bneigh_vals) * div_a;
+
+                    der_sum += f1_sqrt * f1_sqrt
+                }
+
+                const HALF: f64x4 = f64x4::splat(0.5);
+                const TFOURTH: f64x4 = f64x4::splat(1.0 / 24.0);
+
+                let site_vals2 = site_vals * site_vals;
+                let site_vals4 = site_vals2 * site_vals2;
+
+                let kinetic = HALF * der_sum;
+                let mass = HALF * msquared * site_vals2;
+                let inter = TFOURTH * coupling * site_vals4;
+
+                a4 * (kinetic + mass + inter)
+            })
+            .reduce(
+                || f64x4::splat(0.0),
+                |a, b| a + b
+            )
+            .reduce_sum();
+
+        action_red + action_black
+    }
+
 }

--- a/lqft/src/sim.rs
+++ b/lqft/src/sim.rs
@@ -4,15 +4,15 @@ use crate::snapshot::{SnapshotState};
 use crate::stats::SystemStats;
 use atomic_float::AtomicF64;
 use hdf5_metno::H5Type;
-use num_traits::Pow;
+use num_traits::Zero;
 use rand_xoshiro::rand_core::{Rng, SeedableRng};
-use rand_xoshiro::{Xoshiro256PlusPlus, rand_core};
+use rand_xoshiro::{Xoshiro256PlusPlus};
 use rayon::prelude::*;
-use serde::Deserialize;
-use serde::Serialize;
-use std::ops::{Div, Range};
+use realfft::RealFftPlanner;
+use rustfft::FftPlannerAvx;
+use rustfft::num_complex::Complex;
 use std::simd::num::SimdFloat;
-use std::simd::{f64x4, u64x8, usizex4, Select, Simd, StdFloat};
+use std::simd::{f64x4, usizex4, Select, StdFloat};
 use std::simd::prelude::SimdPartialOrd;
 use std::sync::atomic::Ordering;
 use std::sync::atomic::{AtomicBool};
@@ -27,7 +27,7 @@ const CTR: usizex4 = usizex4::from_array([0, 1, 2, 3]);
 const TWO: usizex4 = usizex4::splat(2);
 
 /// Simulation settings that should be saved to the archive.
-#[derive(H5Type, Serialize, Deserialize)]
+#[derive(H5Type)]
 #[repr(C)]
 pub struct SystemSettings {
     pub spacing: f64,
@@ -59,7 +59,9 @@ pub struct SystemData {
     pub measurement_interval: usize,
     pub current_step_size: AtomicF64,
     pub stats: SystemStats,
-    pub successful_therm_checks: usize
+    pub successful_therm_checks: usize,
+
+    pub autocorrelation_samples: Vec<f64>
 }
 
 all_public_in!(
@@ -187,7 +189,7 @@ impl System {
             }
 
             const HALF: f64x4 = f64x4::splat(0.5);
-            const TFOURTH: f64x4 = f64x4::splat(1.0 / 24.0);;
+            const TFOURTH: f64x4 = f64x4::splat(1.0 / 24.0);
 
             let msquared = f64x4::splat(mass_squared);
             let coupling = f64x4::splat(coupling);
@@ -260,7 +262,6 @@ impl System {
 
             let step_size = self.current_step_size();
 
-            let action = &mut self.data.stats.current_action;
             let accepted_moves = &self.data.stats.accepted_moves;
             let total_moves = &self.data.stats.total_moves;
 
@@ -337,8 +338,39 @@ impl System {
                 }
             }
 
+            const AUTOCOR_SAMPLE_SIZE: usize = 50;
+
             if self.data.stats.thermalised_at.is_none() {
                 self.correct_step_size();
+            } else {
+                // Store samples to estimate autocorrelation time.
+                // self.data.autocorrelation_samples.push(self.lattice().mean());
+                self.data.autocorrelation_samples.push(self.compute_full_action());
+            }
+
+            if self.data.autocorrelation_samples.len() == AUTOCOR_SAMPLE_SIZE {
+                // Estimate autocorrelation time
+                let series_mean = self.data.autocorrelation_samples.iter().sum::<f64>() / AUTOCOR_SAMPLE_SIZE as f64;
+                let mut series = self.data.autocorrelation_samples.iter().map(|m| m - series_mean).collect::<Vec<_>>();
+                series.resize(2 * series.len(), 0.0);
+
+                let mut planner = RealFftPlanner::<f64>::new();
+                let fft = planner.plan_fft_forward(series.len());
+
+                let mut freq = fft.make_output_vec();
+                fft.process(&mut series, &mut freq).unwrap();
+
+                freq.iter_mut().for_each(|s| *s = *s * s.conj());
+
+                let inv_fft = planner.plan_fft_inverse(series.len());
+                let mut autocov = inv_fft.make_output_vec();
+                inv_fft.process(&mut freq, &mut autocov).unwrap();
+
+                let c0 = autocov[0];
+                let rho: Vec<f64> = autocov[..self.data.autocorrelation_samples.len()].iter().map(|&c| c / c0).collect();
+
+                let tau_int = 0.5 + rho[1..].iter().take_while(|&r| *r > 0.0).sum::<f64>();
+                println!("Autocorrelation time: {tau_int}");
             }
 
             // Record statistics on every sweep.
@@ -478,20 +510,6 @@ impl System {
             .reduce_sum();
 
         action_red + action_black
-    }
-
-    fn get_timeslice(&mut self) -> Vec<f64> {
-        // Compute the spatial sum for every time slice
-        let st = self.data.lattice.dim_t();
-
-        let mut sum_t = vec![0.0; st];
-        // for i in 0..self.data.lattice.sweep_size() {
-        //     let t = self.data.lattice.from_index(i)[0];
-        //     let val = unsafe { *self.data.lattice[i].get() };
-        //     sum_t[t] += val;
-        // }
-
-        sum_t
     }
 }
 

--- a/lqft/src/sim.rs
+++ b/lqft/src/sim.rs
@@ -1,26 +1,22 @@
 use crate::lattice::Lattice;
+use crate::observable_impl::MeanValue;
 use crate::setup::{AcceptanceDesc, BurnInDesc};
 use crate::snapshot::{SnapshotState};
 use crate::stats::SystemStats;
 use atomic_float::AtomicF64;
 use hdf5_metno::H5Type;
-use num_traits::Zero;
 use rand_xoshiro::rand_core::{Rng, SeedableRng};
 use rand_xoshiro::{Xoshiro256PlusPlus};
 use rayon::prelude::*;
 use realfft::RealFftPlanner;
-use rustfft::FftPlannerAvx;
-use rustfft::num_complex::Complex;
 use std::simd::num::SimdFloat;
 use std::simd::{f64x4, usizex4, Select, StdFloat};
 use std::simd::prelude::SimdPartialOrd;
 use std::sync::atomic::Ordering;
-use std::sync::atomic::{AtomicBool};
 use std::time::Instant;
 use rand::RngExt;
-use crate::observable::{Observable, ObservableRegistry};
+use crate::observable::{Observable, ObservableHList, ObservableStorage};
 use crate::metrics::MetricState;
-use crate::all_public_in;
 
 const LANES: usize = 4;
 const CTR: usizex4 = usizex4::from_array([0, 1, 2, 3]);
@@ -53,10 +49,7 @@ pub struct SystemData {
     pub coupling: f64,
     pub acceptance_desc: AcceptanceDesc,
     pub burn_in_desc: BurnInDesc,
-    /// A vector for every possible C(t)
-    /// where the inner vector is for every sweep
-    pub correlation_slices: Vec<f64>,
-    pub measurement_interval: usize,
+
     pub current_step_size: AtomicF64,
     pub stats: SystemStats,
     pub successful_therm_checks: usize,
@@ -64,16 +57,13 @@ pub struct SystemData {
     pub autocorrelation_samples: Vec<f64>
 }
 
-all_public_in!(
-    super,
-    pub struct System {
-        simulating: AtomicBool,
-        metrics: MetricState,
-        snapshot_state: Option<SnapshotState>,
-        observables: ObservableRegistry,
-        data: SystemData
-    }
-);
+pub struct System<O: ObservableHList> {
+    pub simulating: bool,
+    pub metrics: MetricState,
+    pub snapshot: Option<SnapshotState>,
+    pub observables: ObservableStorage<O>,
+    pub data: SystemData
+}
 
 #[inline(always)]
 fn to_coord(idx: usizex4, dims: [usize; 4]) -> [usizex4; 4] {
@@ -130,7 +120,7 @@ fn find_bneighbors(site_idx: usizex4, dims: [usize; 4], dir: usize) -> usizex4 {
 }
 
 
-impl System {
+impl<T: ObservableHList> System<T> {
     /// Attempts to flip 8 sites starting from `idx`, returning the change in action.
     #[inline(always)]
     fn flip_site_chunk<R: Rng>(
@@ -235,13 +225,11 @@ impl System {
 
         tracing::debug!("Starting action is: {action}");
 
-        if let Some(state) = &mut self.snapshot_state {
+        if let Some(state) = &mut self.snapshot {
             state.init(self.data.lattice.dimensions(), total_sweeps)?;
         }
 
         self.data.stats.reserve_capacity(total_sweeps);
-        self.data.correlation_slices
-            .resize(self.data.lattice.dimensions()[0], 0.0);
 
         tracing::info!("Running {total_sweeps} sweeps...");
 
@@ -258,7 +246,7 @@ impl System {
             self.data.stats.current_sweep = i;
 
             // First update red sites....
-            self.simulating.store(true, Ordering::SeqCst);
+            self.simulating = true;
 
             let step_size = self.current_step_size();
 
@@ -306,7 +294,7 @@ impl System {
                 }
             );
 
-            self.simulating.store(false, Ordering::SeqCst);
+            self.simulating = false;
 
             let sweep_time = sweep_timer.elapsed();
             sweep_timer = Instant::now();
@@ -338,6 +326,8 @@ impl System {
                 }
             }
 
+            self.observables.observe_all(&self.data);
+
             const AUTOCOR_SAMPLE_SIZE: usize = 50;
 
             if self.data.stats.thermalised_at.is_none() {
@@ -345,7 +335,8 @@ impl System {
             } else {
                 // Store samples to estimate autocorrelation time.
                 // self.data.autocorrelation_samples.push(self.lattice().mean());
-                self.data.autocorrelation_samples.push(self.compute_full_action());
+                self.data.autocorrelation_samples.push(self.observables.measured::<MeanValue>().unwrap_or(0.0));
+                // self.data.autocorrelation_samples.push(self.compute_full_action());
             }
 
             if self.data.autocorrelation_samples.len() == AUTOCOR_SAMPLE_SIZE {
@@ -381,14 +372,10 @@ impl System {
                 total_timer = Instant::now();
             }
 
-            self.observables.measure(&mut self.data);
+            // self.observables.measure(&mut self.data);
         }
-
+        
         self.push_metrics();
-
-        for t in 0..self.data.lattice.dimensions()[0] {
-            self.data.correlation_slices[t] /= self.data.stats.performed_measurements as f64;
-        }
 
         tracing::info!("Run completed");
 
@@ -397,16 +384,12 @@ impl System {
 
     /// Obtains the latest measurements of the given observable.
     #[inline]
-    pub fn measured<O: Observable>(&self) -> Option<f64> {
-        self.observables.measured::<O>()
+    pub fn measured<U: Observable>(&self) -> Option<U::Output> {
+        self.observables.measured::<U>()
     }
 
-    pub fn observables(&self) -> &ObservableRegistry {
+    pub fn observables(&self) -> &ObservableStorage<T> {
         &self.observables
-    }
-
-    pub fn observables_mut(&mut self) -> &mut ObservableRegistry {
-        &mut self.observables
     }
 
     /// Computes the autocorrelation time of the system in its current state.
@@ -511,10 +494,7 @@ impl System {
 
         action_red + action_black
     }
-}
 
-/// Getters and setters
-impl System {
     /// The current statistics of the simulation.
     pub fn stats(&self) -> &SystemStats {
         &self.data.stats
@@ -536,10 +516,6 @@ impl System {
     /// See [`SystemBuilder::th_block_size`](SystemBuilder::th_block_size) for more information.
     pub fn th_block_size(&self) -> usize {
         self.data.burn_in_desc.block_size
-    }
-
-    pub fn correlator2(&self) -> &[f64] {
-        &self.data.correlation_slices
     }
 
     /// The current mass squared.

--- a/lqft/src/snapshot.rs
+++ b/lqft/src/snapshot.rs
@@ -2,7 +2,6 @@ use crate::lattice::Lattice;
 use crate::setup::{FlushMethod, SnapshotDesc, SnapshotType};
 use crate::stats::SweepStats;
 use hdf5_metno as hdf5;
-use ndarray::{Array5, ArrayView4, ArrayView5, Axis};
 use std::sync::{Arc, mpsc};
 use std::thread;
 use std::thread::JoinHandle;
@@ -44,7 +43,7 @@ impl SnapshotState {
         Ok(())
     }
 
-    fn sequential_job(desc: JobDesc) {
+    fn sequential_job(_desc: JobDesc) {
         // tracing::info!("Initialised sequential snapshot flush thread");
         //
         // let JobDesc {
@@ -87,7 +86,7 @@ impl SnapshotState {
         todo!();
     }
 
-    fn batch_job(desc: JobDesc, batch_size: usize) {
+    fn batch_job(_desc: JobDesc, _batch_size: usize) {
         // tracing::info!("Initialised snapshot batch flush thread");
         //
         // let JobDesc {

--- a/lqft/src/stats.rs
+++ b/lqft/src/stats.rs
@@ -21,14 +21,6 @@ pub struct SystemStats {
     pub accept_ratio_history: Vec<f64>,
     /// History of the step size.
     pub step_size_history: Vec<f64>,
-    /// History of the field mean
-    pub mean_history: Vec<f64>,
-    /// History of the field variance.
-    pub meansq_history: Vec<f64>,
-    /// History of the action over time.
-    pub action_history: Vec<f64>,
-    /// The action at the current point in time.
-    pub current_action: f64,
     /// The history of the thermalisation ratio.
     pub thermalisation_ratio_history: Vec<f64>,
     /// The sweep at which the system first passed the thermalisation threshold.
@@ -47,9 +39,6 @@ pub struct SweepStats {
     pub accepted_moves: u64,
     pub accept_ratio: f64,
     pub step_size: f64,
-    pub mean: f64,
-    pub meansq: f64,
-    pub action: f64,
     pub th_ratio: f64,
     pub performed_measurements: usize,
     pub sweep_time: u128,
@@ -65,14 +54,6 @@ impl<T: ObservableHList> System<T> {
         sweep: usize,
         total_sweeps: usize,
     ) -> anyhow::Result<()> {
-        let mean = self.data.lattice.mean_seq();
-        let meansq = self.data.lattice.meansq();
-        let action = self.data.stats.current_action;
-
-        self.data.stats.mean_history.push(mean);
-        self.data.stats.meansq_history.push(meansq);
-        self.data.stats.action_history.push(action);
-
         let accept = self.data.stats.accepted_moves();
         let total = self.data.stats.total_moves();
         let ratio = accept as f64 / total as f64 * 100.0;
@@ -107,9 +88,6 @@ impl<T: ObservableHList> System<T> {
                     accepted_moves: accept,
                     accept_ratio: ratio,
                     step_size: self.current_step_size(),
-                    mean,
-                    meansq: 0.0,
-                    action,
                     th_ratio: 0.0,
                     performed_measurements: 0,
                     sweep_time: sweep_time.as_micros(),
@@ -145,17 +123,9 @@ impl SystemStats {
         self.accepted_move_history.reserve(count);
         self.accept_ratio_history.reserve(count);
         self.step_size_history.reserve(count);
-        self.mean_history.reserve(count);
-        self.meansq_history.reserve(count);
-        self.action_history.reserve(count);
         self.thermalisation_ratio_history.reserve(count);
         self.stats_time_history.reserve(count);
         self.sweep_time_history.reserve(count);
-    }
-
-    /// The most recent value of the whole system action.
-    pub fn current_action(&self) -> f64 {
-        self.current_action
     }
 
     /// The total amount of attempted moves so far.
@@ -174,15 +144,11 @@ impl Default for SystemStats {
         Self {
             current_sweep: 0,
             desired_sweeps: 0,
-            current_action: 0.0,
             total_moves: AtomicU64::new(0),
             accepted_move_history: Vec::new(),
             accepted_moves: AtomicU64::new(0),
             accept_ratio_history: Vec::new(),
             step_size_history: Vec::new(),
-            mean_history: Vec::new(),
-            meansq_history: Vec::new(),
-            action_history: Vec::new(),
             thermalisation_ratio_history: Vec::new(),
             thermalised_at: None,
             performed_measurements: 0,

--- a/lqft/src/stats.rs
+++ b/lqft/src/stats.rs
@@ -1,8 +1,7 @@
 use crate::setup::SnapshotType;
 use crate::sim::System;
 use crate::snapshot::SnapshotFragment;
-use atomic_float::AtomicF64;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 /// Statistics of the simulation. Every finished sweep, a new statistic is recorded.
@@ -99,7 +98,7 @@ impl System {
                     tracing::info!("Last sweep avg is: {}", self.data.lattice.mean_seq());
                 }
 
-                let clone = unsafe { self.data.lattice.clone() };
+                let clone = self.data.lattice.clone();
 
                 let stats_time = stat_timer.elapsed().as_millis();
                 let sweep = SweepStats {

--- a/lqft/src/stats.rs
+++ b/lqft/src/stats.rs
@@ -1,3 +1,4 @@
+use crate::observable::ObservableHList;
 use crate::setup::SnapshotType;
 use crate::sim::System;
 use crate::snapshot::SnapshotFragment;
@@ -55,7 +56,7 @@ pub struct SweepStats {
     pub stats_time: u128,
 }
 
-impl System {
+impl<T: ObservableHList> System<T> {
     /// Records statistics on the current sweep.
     pub(crate) fn record_stats(
         &mut self,
@@ -85,7 +86,7 @@ impl System {
 
         // Generate snapshot if snapshotting is enabled and an interval is passed *or* this is the
         // last sweep.
-        if let Some(snapshot) = &self.snapshot_state {
+        if let Some(snapshot) = &self.snapshot {
             let should_snapshot = match snapshot.desc.ty {
                 SnapshotType::Checkpoint => sweep == total_sweeps - 1,
                 SnapshotType::Interval(interval) => {


### PR DESCRIPTION
Implements the new observables API and automatically computes autocorrelation times for observables.



An observable can be created by implementing the `Observable` trait for a struct. This struct can then be added to the system using the `SystemBuilder::with\_observable` function. The code makes use of a compile time HList to store the observables which means there is no runtime dynamic dispatch involved. 





After the system has thermalised, the system will measure all observables on every sweep. This information is then used to compute the autocorrelation time for each observables using the FFT method. This method works as follows:



Collect all observables into a time series and then subtract the mean of the \*entire\* series from each entry to normalise it. We then double the list in size, filling the remainder with zeroes. After this we take the Fast Fourier Transform of this list and multiply the last by its conjugate. We then take the inverse FFT of this list to obtain the autocorrelation.



To get the (integrated) autocorrelation time we finally divide the whole list by the first element and compute

```math

\\tau = \\frac{1}{2} + \\sum\_{i = 1}^N \\rho(i)

```

This autocorrelation time tells us how many sweeps to discard between measurements. 



To determine `N` we use the Madras-Sokal window method. This method reduces the noise that is introduced by higher frequencies. For this we choose some `W` such that 

```math 

W = c \\tau\_{\\text{int}} (W)

``` 

for `c` approximately 5. This `W` is found by starting with `W = 1` and incrementing until the condition is satisfied. Once the autocorrelation times are established, measurements will only be taken every 2 autocorrelation times for each observable. 



While the simulation is running, we then recompute the autocorrelation times periodically.

Closes #9
Closes #8 

